### PR TITLE
Datepicker background on Firefox - closes #59

### DIFF
--- a/app/components/DayPickerInput/index.tsx
+++ b/app/components/DayPickerInput/index.tsx
@@ -24,7 +24,7 @@ const DayPickerInput = (props: DayPickerInputProps) => (
     )}
     overlayComponent={(overlayProps: unknown) => (
       <div
-        className="absolute z-10 flex rounded-lg border border-main bg-glass text-white backdrop-blur-xl duration-300 hover:cursor-pointer hover:bg-slate-700"
+        className="absolute z-10 flex rounded-lg border border-main bg-glass text-white backdrop-blur-lg duration-300 hover:cursor-pointer hover:bg-slate-700 firefox:bg-slate-750"
         {...overlayProps}
       />
     )}

--- a/app/components/GameCard/index.tsx
+++ b/app/components/GameCard/index.tsx
@@ -17,7 +17,7 @@ const GameCard = ({
   clock,
   details = true,
 }: GameCardProps) => (
-  <article className="flex rounded-lg border border-main bg-glass text-white backdrop-blur-xl duration-300 hover:cursor-pointer hover:bg-slate-700">
+  <article className="flex rounded-lg border border-main bg-glass text-white backdrop-blur-xl duration-300 hover:cursor-pointer hover:bg-slate-700 firefox:bg-slate-750">
     <div className="flex w-full flex-col">
       <div className="flex p-6">
         <TeamInfo team={vTeam} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,14 @@
+const plugin = require('tailwindcss/plugin')
+
 module.exports = {
   content: ['./app/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      colors: {
+        slate: {
+          750: '#293649',
+        },
+      },
       borderColor: {
         main: 'rgba(255, 255, 255, 0.24)',
       },
@@ -15,5 +22,21 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addVariant, e, postcss }) {
+      addVariant('firefox', ({ container, separator }) => {
+        const isFirefoxRule = postcss.atRule({
+          name: '-moz-document',
+          params: 'url-prefix()',
+        })
+        isFirefoxRule.append(container.nodes)
+        container.append(isFirefoxRule)
+        isFirefoxRule.walkRules((rule) => {
+          rule.selector = `.${e(
+            `firefox${separator}${rule.selector.slice(1)}`,
+          )}`
+        })
+      })
+    }),
+  ],
 }


### PR DESCRIPTION
This add a custom function to Tailwind that add a fallback to Firefox non supported filters, based on this [post](https://braydoncoyer.dev/blog/build-a-glassmorphic-navbar-with-tailwindcss-backdrop-filter-and-backdrop-blur#don't-leave-out-firefox).

Firefox:
![Screen Shot 2022-03-06 at 21 03 56](https://user-images.githubusercontent.com/3428733/156951895-532e418a-1b48-4111-99a7-3dfb6780920f.png)

Chrome:
![Screen Shot 2022-03-06 at 21 04 06](https://user-images.githubusercontent.com/3428733/156951905-99f56299-1dd9-4524-bd35-732da4b77b62.png)

