### PR TITLE
Caching responses

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -105,3 +105,4 @@ export const DATE_LINK_FORMAT = 'yyyyMMdd'
 export const EST_IANA_ZONE_ID = 'America/New_York'
 
 export const TIME_TO_REFETCH = 20000 // 20s
+export const A_YEAR_IN_SECONDS = 3154e7

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -45,7 +45,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     data: { games },
   } = await API.getGamesByDate(params.date)
 
-  return cachedJson({ games, requestInfo }, { cdn: 60 })
+  return cachedJson({ games, requestInfo })
 }
 
 export default function Index() {

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { json, LinksFunction, useLoaderData, useParams } from 'remix'
+import { LinksFunction, useLoaderData, useParams } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -12,6 +12,7 @@ import { DATE_DISPLAY_FORMAT, TIME_TO_REFETCH } from '~/constants'
 
 import useRevalidateOnInterval from '~/hooks/use-revalidate-on-interval'
 
+import { cachedJson } from '~/utils/cachedJson'
 import { getDays } from '~/utils/handleApiDates'
 import { getSocialMetas, getUrl } from '~/utils/seo'
 
@@ -44,18 +45,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     data: { games },
   } = await API.getGamesByDate(params.date)
 
-  return json(
-    {
-      games,
-      requestInfo,
-    },
-    {
-      headers: {
-        'cache-control':
-          'public, max-age=1, s-maxage=30, stale-while-revalidate=31540000000',
-      },
-    },
-  )
+  return cachedJson({ games, requestInfo }, { cdn: 60 })
 }
 
 export default function Index() {

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { LinksFunction, useLoaderData, useParams } from 'remix'
+import { json, LinksFunction, useLoaderData, useParams } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -44,10 +44,18 @@ export const loader: LoaderFunction = async ({ params, request }) => {
     data: { games },
   } = await API.getGamesByDate(params.date)
 
-  return {
-    games,
-    requestInfo,
-  }
+  return json(
+    {
+      games,
+      requestInfo,
+    },
+    {
+      headers: {
+        'cache-control':
+          'public, max-age=1, s-maxage=30, stale-while-revalidate=31540000000',
+      },
+    },
+  )
 }
 
 export default function Index() {

--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { useLoaderData } from 'remix'
+import { json, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -45,26 +45,34 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   } = await API.getGameDetails(year, gameId)
 
   // TODO: Move this to a mapper function
-  return {
-    game: {
-      // This is needed because the NBA API returns the date separated
-      startTimeUTC: new Date(`${game.gdtutc} ${game.utctm} UTC`),
-      period: game.p,
-      clock: game.cl,
-      status: game.st,
-      vTeam: {
-        score: game.vls.s,
-        triCode: game.vls.ta,
-        ...game.vls,
+  return json(
+    {
+      game: {
+        // This is needed because the NBA API returns the date separated
+        startTimeUTC: new Date(`${game.gdtutc} ${game.utctm} UTC`),
+        period: game.p,
+        clock: game.cl,
+        status: game.st,
+        vTeam: {
+          score: game.vls.s,
+          triCode: game.vls.ta,
+          ...game.vls,
+        },
+        hTeam: {
+          score: game.hls.s,
+          triCode: game.hls.ta,
+          ...game.hls,
+        },
       },
-      hTeam: {
-        score: game.hls.s,
-        triCode: game.hls.ta,
-        ...game.hls,
+      requestInfo,
+    },
+    {
+      headers: {
+        'cache-control':
+          'public, max-age=1, s-maxage=60, stale-while-revalidate=31540000000',
       },
     },
-    requestInfo,
-  }
+  )
 }
 
 export default function Game() {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { json, LinksFunction, useLoaderData } from 'remix'
+import { LinksFunction, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -12,6 +12,7 @@ import { DATE_LINK_FORMAT, TIME_TO_REFETCH } from '~/constants'
 
 import useRevalidateOnInterval from '~/hooks/use-revalidate-on-interval'
 
+import { cachedJson } from '~/utils/cachedJson'
 import { getDays } from '~/utils/handleApiDates'
 import { getSocialMetas, getUrl } from '~/utils/seo'
 
@@ -40,18 +41,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     data: { games },
   } = await API.getGamesByDate(date)
 
-  return json(
-    {
-      games,
-      requestInfo,
-    },
-    {
-      headers: {
-        'cache-control':
-          'public, max-age=1, s-maxage=30, stale-while-revalidate=31540000000',
-      },
-    },
-  )
+  return cachedJson({ games, requestInfo }, { cdn: 30 })
 }
 
 export default function Index() {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -41,7 +41,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     data: { games },
   } = await API.getGamesByDate(date)
 
-  return cachedJson({ games, requestInfo }, { cdn: 30 })
+  return cachedJson({ games, requestInfo })
 }
 
 export default function Index() {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns'
-import { LinksFunction, useLoaderData } from 'remix'
+import { json, LinksFunction, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -40,10 +40,18 @@ export const loader: LoaderFunction = async ({ request }) => {
     data: { games },
   } = await API.getGamesByDate(date)
 
-  return {
-    games,
-    requestInfo,
-  }
+  return json(
+    {
+      games,
+      requestInfo,
+    },
+    {
+      headers: {
+        'cache-control':
+          'public, max-age=1, s-maxage=30, stale-while-revalidate=31540000000',
+      },
+    },
+  )
 }
 
 export default function Index() {

--- a/app/routes/standings.tsx
+++ b/app/routes/standings.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData } from 'remix'
+import { json, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -33,11 +33,19 @@ export const loader: LoaderFunction = async ({ request }) => {
     },
   } = data
 
-  return {
-    east: conferenceMapper(teams, true),
-    west: conferenceMapper(teams, false),
-    requestInfo,
-  }
+  return json(
+    {
+      east: conferenceMapper(teams, true),
+      west: conferenceMapper(teams, false),
+      requestInfo,
+    },
+    {
+      headers: {
+        'cache-control':
+          'public, max-age=60, s-maxage=600, stale-while-revalidate=31540000000',
+      },
+    },
+  )
 }
 
 export default function Standings() {

--- a/app/routes/standings.tsx
+++ b/app/routes/standings.tsx
@@ -1,10 +1,11 @@
-import { json, useLoaderData } from 'remix'
+import { useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
 import Layout from '~/components/Layout'
 import StandingTable from '~/components/StandingTable'
 
+import { cachedJson } from '~/utils/cachedJson'
 import { conferenceMapper } from '~/utils/mappers'
 import { getSocialMetas, getUrl } from '~/utils/seo'
 
@@ -33,18 +34,13 @@ export const loader: LoaderFunction = async ({ request }) => {
     },
   } = data
 
-  return json(
+  return cachedJson(
     {
       east: conferenceMapper(teams, true),
       west: conferenceMapper(teams, false),
       requestInfo,
     },
-    {
-      headers: {
-        'cache-control':
-          'public, max-age=60, s-maxage=600, stale-while-revalidate=31540000000',
-      },
-    },
+    { browser: 60, cdn: 600 },
   )
 }
 

--- a/app/utils/cachedJson/index.ts
+++ b/app/utils/cachedJson/index.ts
@@ -1,3 +1,5 @@
+import { A_YEAR_IN_SECONDS, TIME_TO_REFETCH } from '~/constants'
+
 type Options = {
   browser?: number
   cdn?: number
@@ -14,7 +16,11 @@ type Options = {
  */
 export function cachedJson(
   data: Record<string, unknown>,
-  { browser = 1, cdn = 60, swr = 3154e7 }: Options = {},
+  {
+    browser = 1,
+    cdn = TIME_TO_REFETCH / 1000, // milliseconds to seconds
+    swr = A_YEAR_IN_SECONDS,
+  }: Options = {},
 ): Response {
   return new Response(JSON.stringify(data), {
     headers: {

--- a/app/utils/cachedJson/index.ts
+++ b/app/utils/cachedJson/index.ts
@@ -1,0 +1,25 @@
+type Options = {
+  browser?: number
+  cdn?: number
+  swr?: number
+}
+/**
+ * Method that returns a cached json response given some cache options
+ * @param data - The response data
+ * @param {Object} options
+ * @param {Object} options.browser - time in seconds for the client's browser to Cache
+ * @param {Object} options.cdn - time in seconds for the CDN to Cache
+ * @param {Object} options.swr - time in seconds for the server cache to expire
+ * @returns Response
+ */
+export function cachedJson(
+  data: Record<string, unknown>,
+  { browser = 1, cdn = 60, swr = 3154e7 }: Options = {},
+): Response {
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': `public, max-age=${browser}, s-maxage=${cdn}, stale-while-revalidate=${swr}`,
+    },
+  })
+}


### PR DESCRIPTION
For even snappier UX.

[Reference](https://www.youtube.com/watch?v=bfLFHp7Sbkg)

![pr2](https://user-images.githubusercontent.com/566971/157065869-b48c5406-5bb3-48be-aa1f-584b621b6145.gif)

I don't have a complete understanding of NBA's API and want to see your ideas on this but we could make `app/routes/$date` route return a long cache for past games, light cache for active games and medium for future games.

I'll explain my caching decisions on comments through the diff, opinions on it are welcome.