### PR TITLE
fix: set empty values to a not started game - closes #80

### DIFF
--- a/app/components/PlayersStats/__snapshots__/test.tsx.snap
+++ b/app/components/PlayersStats/__snapshots__/test.tsx.snap
@@ -49,8 +49,8 @@ exports[`<PlayersStats> should render correctly 1`] = `
           <td
             class="border border-main px-3 py-2 truncate text-left"
           >
-            F
-            . 
+            F.
+             
             Last
           </td>
           <td
@@ -78,8 +78,8 @@ exports[`<PlayersStats> should render correctly 1`] = `
           <td
             class="border border-main px-3 py-2 truncate text-left"
           >
-            S
-            . 
+            S.
+             
             Last
           </td>
           <td

--- a/app/components/PlayersStats/index.tsx
+++ b/app/components/PlayersStats/index.tsx
@@ -2,6 +2,10 @@ import { Table, TableCell, TableHead } from '~/components/Table'
 import type { PlayerStats, TeamPlayerStats } from '~/types'
 
 function PlayersStats({ team }: TeamPlayerStats) {
+  const emptyLabel = '-';
+  const teamPstsg = team?.pstsg || [{}];
+
+
   return (
     <div>
       <h1 className="text-2xl font-bold">
@@ -20,15 +24,15 @@ function PlayersStats({ team }: TeamPlayerStats) {
           </tr>
         </TableHead>
         <tbody>
-          {team.pstsg.map((player: PlayerStats) => (
+          {teamPstsg.map((player: PlayerStats) => (
             <tr key={player.num}>
               <TableCell className="truncate text-left">
-                {player.fn[0]}. {player.ln}
+                {player.fn ? `${player.fn[0]}.` : emptyLabel} {player.ln}
               </TableCell>
-              <TableCell>{player.min}</TableCell>
-              <TableCell>{player.reb}</TableCell>
-              <TableCell>{player.ast}</TableCell>
-              <TableCell>{player.pts}</TableCell>
+              <TableCell>{player.min || emptyLabel}</TableCell>
+              <TableCell>{player.reb || emptyLabel}</TableCell>
+              <TableCell>{player.ast || emptyLabel}</TableCell>
+              <TableCell>{player.pts || emptyLabel}</TableCell>
             </tr>
           ))}
         </tbody>

--- a/app/components/TeamStats/index.tsx
+++ b/app/components/TeamStats/index.tsx
@@ -22,6 +22,10 @@ export function Statistic({
 }
 
 function TeamStats({ game }: TeamGroupStatistics) {
+  const hTeamTstsg = game.hTeam.tstsg || {};
+  const vTeamTstsg = game.vTeam.tstsg || {};
+  const emptyLabel = '-'
+
   return (
     <div>
       <h1 className="text-2xl font-bold">Team Stats</h1>
@@ -40,68 +44,68 @@ function TeamStats({ game }: TeamGroupStatistics) {
           </tr>
 
           <Statistic
-            homeStatistic={`${game.hTeam.tstsg.fgm} / ${game.hTeam.tstsg.fga}`}
-            visitorStatistic={`${game.vTeam.tstsg.fgm} / ${game.vTeam.tstsg.fga}`}
+            homeStatistic={hTeamTstsg.fgm ? `${hTeamTstsg.fgm} / ${hTeamTstsg.fga}` : emptyLabel}
+            visitorStatistic={vTeamTstsg.fgm ? `${vTeamTstsg.fgm} / ${vTeamTstsg.fga}` : emptyLabel}
             label="Field Goals"
           />
 
           <Statistic
-            homeStatistic={`${game.hTeam.tstsg.tpm} / ${game.hTeam.tstsg.tpa}`}
-            visitorStatistic={`${game.vTeam.tstsg.tpm} / ${game.vTeam.tstsg.tpa}`}
+            homeStatistic={hTeamTstsg.tpm ? `${hTeamTstsg.tpm} / ${hTeamTstsg.tpa}` : emptyLabel}
+            visitorStatistic={vTeamTstsg.tpm ? `${vTeamTstsg.tpm} / ${vTeamTstsg.tpa}` : emptyLabel}
             label="3 Pointers"
           />
 
           <Statistic
-            homeStatistic={`${game.hTeam.tstsg.ftm} / ${game.hTeam.tstsg.fta}`}
-            visitorStatistic={`${game.vTeam.tstsg.ftm} / ${game.vTeam.tstsg.fta}`}
+            homeStatistic={hTeamTstsg.ftm ? `${hTeamTstsg.ftm} / ${hTeamTstsg.fta}` : emptyLabel}
+            visitorStatistic={vTeamTstsg.ftm ? `${vTeamTstsg.ftm} / ${vTeamTstsg.fta}` : emptyLabel}
             label="Free throws"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.reb}
-            visitorStatistic={game.vTeam.tstsg.reb}
+            homeStatistic={hTeamTstsg.reb || emptyLabel}
+            visitorStatistic={vTeamTstsg.reb || emptyLabel}
             label="Total Rebounds"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.oreb}
-            visitorStatistic={game.vTeam.tstsg.oreb}
+            homeStatistic={hTeamTstsg.oreb || emptyLabel}
+            visitorStatistic={vTeamTstsg.oreb || emptyLabel}
             label="Offensive Rebounds"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.ast}
-            visitorStatistic={game.vTeam.tstsg.ast}
+            homeStatistic={hTeamTstsg.ast || emptyLabel}
+            visitorStatistic={vTeamTstsg.ast || emptyLabel}
             label="Assists"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.blk}
-            visitorStatistic={game.vTeam.tstsg.blk}
+            homeStatistic={hTeamTstsg.blk || emptyLabel}
+            visitorStatistic={vTeamTstsg.blk || emptyLabel}
             label="Blocks"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.stl}
-            visitorStatistic={game.vTeam.tstsg.stl}
+            homeStatistic={hTeamTstsg.stl || emptyLabel}
+            visitorStatistic={vTeamTstsg.stl || emptyLabel}
             label="Steals"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.tov}
-            visitorStatistic={game.vTeam.tstsg.tov}
+            homeStatistic={hTeamTstsg.tov || emptyLabel}
+            visitorStatistic={vTeamTstsg.tov || emptyLabel}
             label="Turnovers"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.pip}
-            visitorStatistic={game.vTeam.tstsg.pip}
+            homeStatistic={hTeamTstsg.pip || emptyLabel}
+            visitorStatistic={vTeamTstsg.pip || emptyLabel}
             label="Points in the paint"
           />
 
           <Statistic
-            homeStatistic={game.hTeam.tstsg.pf}
-            visitorStatistic={game.vTeam.tstsg.pf}
+            homeStatistic={hTeamTstsg.pf || emptyLabel}
+            visitorStatistic={vTeamTstsg.pf || emptyLabel}
             label="Fouls - Personal"
           />
         </tbody>


### PR DESCRIPTION
Changes:
- Prevent app crashes when a game has not been started yet
- Add a placeholder label to empty values


## Screenshots
Before:
<img width="1139" alt="Screenshot 2022-03-10 at 13 52 23" src="https://user-images.githubusercontent.com/1502981/157675832-959719cb-752e-4eeb-baae-a5777f781031.png">


After:
<img width="1282" alt="Screenshot 2022-03-10 at 13 49 33" src="https://user-images.githubusercontent.com/1502981/157675850-71013fef-4bdd-47fc-8352-b80a8c7012dd.png">

