### PR TITLE
Align date arrows in mobile - closes #83

### DIFF
--- a/app/components/DateSelector/index.tsx
+++ b/app/components/DateSelector/index.tsx
@@ -17,7 +17,7 @@ function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
   return (
     <div className="flex flex-col py-12">
       <h1 className="mb-3 text-4xl font-bold">Games</h1>
-      <div className="justify-center -mx-2 flex items-center gap-5 sm:justify-start">
+      <div className="justify-between pt-4 flex items-center gap-5 sm:justify-start">
         <Link
           prefetch="intent"
           className="p-2"

--- a/app/components/DateSelector/index.tsx
+++ b/app/components/DateSelector/index.tsx
@@ -17,7 +17,7 @@ function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
   return (
     <div className="flex flex-col py-12">
       <h1 className="mb-3 text-4xl font-bold">Games</h1>
-      <div className="-ml-2 flex items-center gap-5">
+      <div className="justify-center -mx-2 flex items-center gap-5 sm:justify-start">
         <Link
           prefetch="intent"
           className="p-2"


### PR DESCRIPTION
Aligns date arrows in mobile. I used justify-center because I think it looks better, but maybe the idea was to justify between.

![image](https://user-images.githubusercontent.com/63605334/157794312-38c02ce8-5041-4a31-b3a7-68a228dbd9fb.png)

Closes #83