### PR TITLE
Feat: Adding "Go to today" button - closes #87

### DIFF
--- a/app/components/DayPickerInput/index.tsx
+++ b/app/components/DayPickerInput/index.tsx
@@ -3,6 +3,10 @@ import BaseDayPickerInput from 'react-day-picker/DayPickerInput'
 import styles from 'react-day-picker/lib/style.css'
 import customStyles from './styles.css'
 
+interface IDayPickerInputProps extends DayPickerInputProps {
+  onDayChange: (selectedDay: Date) => void
+}
+
 export const links = () => [
   { rel: 'stylesheet', href: styles },
   {
@@ -11,7 +15,7 @@ export const links = () => [
   },
 ]
 
-const DayPickerInput = (props: DayPickerInputProps) => (
+const DayPickerInput = (props: IDayPickerInputProps) => (
   <BaseDayPickerInput
     component={(componentProps: unknown) => (
       <input
@@ -26,6 +30,10 @@ const DayPickerInput = (props: DayPickerInputProps) => (
         {...overlayProps}
       />
     )}
+    dayPickerProps={{
+      todayButton: 'Go to today',
+      onTodayButtonClick: (day: any) => props.onDayChange(day),
+    }}
     {...props}
   />
 )

--- a/app/components/DayPickerInput/styles.css
+++ b/app/components/DayPickerInput/styles.css
@@ -20,3 +20,8 @@
   .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
   background-color: #0f172a;
 }
+
+.DayPicker-Footer {
+  width: fit-content;
+  margin: 0 auto;
+}


### PR DESCRIPTION
The feature is mostly working, however, I am trying to fix the bug which occurs when you click a button on the overlay and then click outside the overlay but it remains visible.

This bug was reported here: https://github.com/gpbl/react-day-picker/issues/723