### PR TITLE
[FEATURE] Player/Team Stats tabs in Game page

### DIFF
--- a/app/components/GameCard/index.tsx
+++ b/app/components/GameCard/index.tsx
@@ -29,7 +29,7 @@ const GameCard = ({
   return (
     <article
       className={cn(
-        'flex rounded-lg border border-main bg-glass text-white backdrop-blur-lg duration-300 firefox:bg-slate-750',
+        'flex rounded-lg border border-main bg-glass text-white backdrop-blur-lg duration-300 firefox:bg-slate-750 self-center',
         {
           'hover:cursor-pointer hover:bg-slate-700': interactive,
         },

--- a/app/components/GameSummary/index.tsx
+++ b/app/components/GameSummary/index.tsx
@@ -12,7 +12,7 @@ export type GameSummaryProps = {
 
 function GameSummary({ game }: GameSummaryProps) {
   return (
-    <div className="py-5">
+    <div className="py-3 px-3 max-w-screen-sm">
       <h1 className="text-2xl font-semibold">Game Summary</h1>
       <div className="overflow-x-auto">
         <Table>

--- a/app/components/GameTables/index.tsx
+++ b/app/components/GameTables/index.tsx
@@ -25,10 +25,10 @@ const GameTables = ({
   return (
     <>
       <Tabs>
-        <TabList className="flex flex-row">
-          <Tab className="basis-1/3 cursor-pointer">{vTeam.tn}</Tab>
-          <Tab className="basis-1/3 cursor-pointer">{hTeam.tn}</Tab>
-          <Tab className="basis-1/3 cursor-pointer">Stats</Tab>
+        <TabList className="flex flex-row items-stretch">
+          <Tab className="basis-1/3 cursor-pointer text-center">{vTeam.tn}</Tab>
+          <Tab className="basis-1/3 cursor-pointer text-center">{hTeam.tn}</Tab>
+          <Tab className="basis-1/3 cursor-pointer text-center">Stats</Tab>
         </TabList>
 
         <TabPanel>

--- a/app/components/GameTables/index.tsx
+++ b/app/components/GameTables/index.tsx
@@ -1,0 +1,48 @@
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import customStyles from './style.css'
+import PlayerStats from '~/components/PlayersStats'
+import TeamStats from '~/components/TeamStats'
+import type { TeamPlayerStats } from '~/types'
+
+
+export const links = () => [
+  {
+    rel: 'stylesheet',
+    href: customStyles,
+  }
+]
+
+export type GameTablesProps = {
+  vTeam: TeamPlayerStats,
+  hTeam: TeamPlayerStats,
+  game: any
+}
+const GameTables = ({
+  vTeam,
+  hTeam,
+  game
+}: GameTablesProps) => {
+  return (
+    <>
+      <Tabs>
+        <TabList className="flex flex-row">
+          <Tab className="basis-1/3 cursor-pointer">{vTeam.tn}</Tab>
+          <Tab className="basis-1/3 cursor-pointer">{hTeam.tn}</Tab>
+          <Tab className="basis-1/3 cursor-pointer">Stats</Tab>
+        </TabList>
+
+        <TabPanel>
+          <PlayerStats team={game.vTeam} />
+        </TabPanel>
+        <TabPanel>
+          <PlayerStats team={game.hTeam} />          
+        </TabPanel>
+        <TabPanel>
+           <TeamStats game={game} />
+        </TabPanel>
+      </Tabs>     
+    </>
+  )
+}
+
+export default GameTables

--- a/app/components/GameTables/style.css
+++ b/app/components/GameTables/style.css
@@ -1,0 +1,13 @@
+.react-tabs .react-tabs__tab-list {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-bottom: 0;
+  list-style: none;
+  padding: 0;
+  border-bottom: 1px solid #e6e6e6;
+}
+
+.react-tabs__tab--selected {
+  border-bottom: 10px solid #e6e6e6;
+}

--- a/app/components/Layout/index.tsx
+++ b/app/components/Layout/index.tsx
@@ -9,7 +9,7 @@ function Layout({ children }: LayoutProps) {
   return (
     <div className="flex min-h-screen flex-col bg-slate-900 bg-main bg-cover bg-center pb-24 text-white">
       <Header />
-      <main className="container mx-auto flex-grow px-4">{children}</main>
+      <main className="container mx-auto flex-grow px-4 self-center">{children}</main>
       <Footer />
     </div>
   )

--- a/app/components/PlayersStats/index.tsx
+++ b/app/components/PlayersStats/index.tsx
@@ -4,9 +4,9 @@ import type { PlayerStats, TeamPlayerStats } from '~/types'
 function PlayersStats({ team }: TeamPlayerStats) {
   return (
     <div>
-      <h1 className="text-2xl font-bold">
+      {/* <h1 className="text-2xl font-bold">
         {team.tc} {team.tn}
-      </h1>
+      </h1> */}
       <Table>
         <TableHead>
           <tr>

--- a/app/components/StandingTable/index.tsx
+++ b/app/components/StandingTable/index.tsx
@@ -23,7 +23,7 @@ export type StandingTableProps = {
 function StandingTable({ label, conference }: StandingTableProps) {
   return (
     <div className="overflow-x-auto py-5">
-      <h1 className="text-3xl font-bold text-white">{label}</h1>
+      {/* <h1 className="text-3xl font-bold text-white">{label}</h1> */}
       <Table fullWidth>
         <TableHead>
           <tr>

--- a/app/components/Table/index.tsx
+++ b/app/components/Table/index.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames'
 
 export function Table({
-  fullWidth = false,
+  fullWidth = true,
   children,
 }: React.PropsWithChildren<{ fullWidth?: boolean }>) {
   return (

--- a/app/components/TeamStats/index.tsx
+++ b/app/components/TeamStats/index.tsx
@@ -24,7 +24,7 @@ export function Statistic({
 function TeamStats({ game }: TeamGroupStatistics) {
   return (
     <div>
-      <h1 className="text-2xl font-bold">Team Stats</h1>
+      {/* <h1 className="text-2xl font-bold">Team Stats</h1> */}
       <Table>
         <tbody>
           <tr>

--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -6,9 +6,10 @@ import API from '~/api'
 import ArrowIcon from '~/components/ArrowIcon'
 import GameCard from '~/components/GameCard'
 import GameSummary from '~/components/GameSummary'
+import GameTables from '~/components/GameTables'
 import Layout from '~/components/Layout'
-import PlayerStats from '~/components/PlayersStats'
-import TeamStats from '~/components/TeamStats'
+// import PlayerStats from '~/components/PlayersStats'
+// import TeamStats from '~/components/TeamStats'
 
 import { DATE_DISPLAY_FORMAT, GAME_STATUS, TIME_TO_REFETCH } from '~/constants'
 
@@ -103,10 +104,17 @@ export default function Game() {
           <GameSummary game={game} />
 
           <div className="flex gap-4 overflow-x-auto md:gap-12 ">
-            <PlayerStats team={game.hTeam} />
-            <PlayerStats team={game.vTeam} />
 
-            <TeamStats game={game} />
+            <GameTables
+              vTeam={game.vTeam}
+              hTeam={game.hTeam}
+              game={game}
+            />
+
+            {/* <PlayerStats team={game.hTeam} />
+            <PlayerStats team={game.vTeam} />
+            <TeamStats game={game} /> */}
+            
           </div>
         </>
       )}

--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -84,7 +84,7 @@ export default function Game() {
         <span className="pl-3 text-xl">Back</span>
       </div>
 
-      <div className="py-5 md:max-w-sm">
+      <div className="py-3 px-3 max-w-screen-sm self-center">
         <GameCard
           vTeam={game.vTeam}
           hTeam={game.hTeam}
@@ -103,7 +103,7 @@ export default function Game() {
         <>
           <GameSummary game={game} />
 
-          <div className="flex gap-4 overflow-x-auto md:gap-12 ">
+          <div className="py-3 px-3 max-w-screen-sm">
 
             <GameTables
               vTeam={game.vTeam}
@@ -114,7 +114,7 @@ export default function Game() {
             {/* <PlayerStats team={game.hTeam} />
             <PlayerStats team={game.vTeam} />
             <TeamStats game={game} /> */}
-            
+
           </div>
         </>
       )}

--- a/app/routes/standings.tsx
+++ b/app/routes/standings.tsx
@@ -1,3 +1,4 @@
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
@@ -49,8 +50,25 @@ export default function Standings() {
 
   return (
     <Layout>
-      <StandingTable label="Eastern Conference" conference={east} />
-      <StandingTable label="Western Conference" conference={west} />
+      <Tabs>
+        <TabList className="flex flex-row items-stretch">
+          <Tab className="basis-1/2 cursor-pointer text-center">
+            <h1 className="text-3xl font-bold text-white">Western Conference</h1>
+          </Tab>
+          <Tab className="basis-1/2 cursor-pointer text-center">
+            <h1 className="text-3xl font-bold text-white">Eastern Conference</h1>
+          </Tab>
+        </TabList>
+
+        <TabPanel>
+           <StandingTable label="Western Conference" conference={west} />    
+        </TabPanel>
+        <TabPanel>
+          <StandingTable label="Eastern Conference" conference={east} />
+        </TabPanel>
+      </Tabs>  
+      {/* <StandingTable label="Eastern Conference" conference={east} />
+      <StandingTable label="Western Conference" conference={west} /> */}
     </Layout>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-day-picker": "^7.4.10",
         "react-dom": "^17.0.2",
         "react-nba-logos": "^1.1.3",
+        "react-tabs": "^4.0.1",
         "remix": "^1.2.3",
         "remix-utils": "^2.7.0",
         "url-join": "^4.0.1"
@@ -40,6 +41,7 @@
         "@types/nprogress": "^0.2.0",
         "@types/react": "^17.0.40",
         "@types/react-dom": "^17.0.13",
+        "@types/react-tabs": "^2.3.4",
         "@types/url-join": "^4.0.1",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
@@ -7702,6 +7704,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-tabs": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+      "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -10826,7 +10837,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -24597,6 +24607,18 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/react-tabs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.0.1.tgz",
+      "integrity": "sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-0"
+      }
+    },
     "node_modules/react-textarea-autosize": {
       "version": "8.3.3",
       "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
@@ -36087,6 +36109,15 @@
         "@types/react": "*"
       }
     },
+    "@types/react-tabs": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.4.tgz",
+      "integrity": "sha512-HQzhKW+RF/7h14APw/2cu4Nnt+GmsTvfBKbFdn/NbYpb8Q+iB65wIkPHz4VRKDxWtOpNFpOUtzt5r0LRmQMfOA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -38529,8 +38560,7 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
-      "dev": true
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "co": {
       "version": "4.6.0",
@@ -48862,6 +48892,15 @@
         "lowlight": "^1.14.0",
         "prismjs": "^1.21.0",
         "refractor": "^3.1.0"
+      }
+    },
+    "react-tabs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-4.0.1.tgz",
+      "integrity": "sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
       }
     },
     "react-textarea-autosize": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-day-picker": "^7.4.10",
     "react-dom": "^17.0.2",
     "react-nba-logos": "^1.1.3",
+    "react-tabs": "^4.0.1",
     "remix": "^1.2.3",
     "remix-utils": "^2.7.0",
     "url-join": "^4.0.1"
@@ -51,6 +52,7 @@
     "@types/nprogress": "^0.2.0",
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.13",
+    "@types/react-tabs": "^2.3.4",
     "@types/url-join": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",


### PR DESCRIPTION
Initial proposal to resolve #46,
put team and player stats in tabs functionality, and extend this functionality to standings page. 

I'm using [react-tabs](https://github.com/reactjs/react-tabs) for this issue/feature

![image1](https://user-images.githubusercontent.com/550632/158034031-235e0da1-c110-4da6-aab9-ff6cc4f5d926.png)
![image2](https://user-images.githubusercontent.com/550632/158033976-d5d19693-9f2b-459f-b6c2-4aa2e7ac55be.png)


#### Need some help in styling and TS Typo waning.

# [[ WIP ]]
Roadmap:
- [X] Add tabs to players/teams game page (image1)
- [X] Add tabs to standings page (image2)
- [X] Tables width inside panels
- [X] General styling
- [ ] Mobile Players table width not fit screen
- [ ] Tab selected and tabs line styling
- [ ] Storybook entry
- [ ] Test entry
- [ ] Warning on use `vTeam` with  `TeamPlayerStats` type
- [ ] `react-tabs`: Warning in Prop `id` did not match. Server: `react-tabs-90` Client: `react-tabs-0`
- [ ] Remove comments and unused code
- [ ] Fixing fail tests from modified components