### PR TITLE
Change to named export and format files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,13 +16,61 @@
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "react/react-in-jsx-scope": "off",
+    "import/prefer-default-export": "off",
+    "import/no-default-export": "error",
     "import/order": [
       "error",
       {
+        "newlines-between": "always",
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "builtin",
+            "position": "before"
+          },
+          {
+            "pattern": "~/api",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "~/constants",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "~/components/**",
+            "group": "external",
+            "position": "after"
+          },
+          {
+            "pattern": "~/utils/**",
+            "group": "external",
+            "position": "after"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object"
+        ],
         "alphabetize": {
           "order": "asc"
         }
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["app/*", "app/routes/**/*.tsx", "app/**/stories.tsx"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
+    }
+  ]
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install lint-staged

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ This project uses [husky](https://www.npmjs.com/package/husky) for pre-commits.
 
 To disable it, add `export HUSKY_SKIP_HOOKS=1` to your shell configuration file (`.zshrc`, `.bashrc`).
 
+## Writing Components
+
+The project favors function components using `function` and avoid using `export default`. Also, always prefer to use `type` instead of `interface`.
+
+When creating a component then the coding style adopted by the project is like this:
+
+```js
+export type MyComponentProps = {
+  myComponentProp?: string,
+}
+
+export function MyComponent({ myComponentProp }: MyComponentProps) {
+  return <>MyComponent</>
+}
+```
+
 ## Maintainers
 
 <table>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Open up [http://localhost:3000](http://localhost:3000) and you should be ready t
 
 If you're used to using the `vercel dev` command provided by [Vercel CLI](https://vercel.com/cli) instead, you can also use that, but it's not needed.
 
+## Pre-commit hook
+
+This project uses [husky](https://www.npmjs.com/package/husky) for pre-commits.
+
+To disable it, add `export HUSKY_SKIP_HOOKS=1` to your shell configuration file (`.zshrc`, `.bashrc`).
+
 ## Maintainers
 
 <table>

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -1,9 +1,6 @@
 import fetch from 'cross-fetch'
 
-export const API_URL = {
-  base: 'http://data.nba.net/prod/',
-  details: 'https://data.nba.com/',
-}
+import { API_URL } from '~/constants'
 
 class API {
   static async getStandings() {
@@ -39,4 +36,5 @@ class API {
   }
 }
 
+// eslint-disable-next-line import/no-default-export
 export default API

--- a/app/components/ArrowIcon/index.tsx
+++ b/app/components/ArrowIcon/index.tsx
@@ -2,7 +2,7 @@ export type ArrowIconProps = {
   size?: number
 } & React.HTMLAttributes<SVGElement>
 
-function ArrowIcon({ size = 12, ...rest }: ArrowIconProps) {
+export function ArrowIcon({ size = 12, ...rest }: ArrowIconProps) {
   return (
     <svg
       fill="none"
@@ -28,5 +28,3 @@ function ArrowIcon({ size = 12, ...rest }: ArrowIconProps) {
     </svg>
   )
 }
-
-export default ArrowIcon

--- a/app/components/ArrowIcon/stories.tsx
+++ b/app/components/ArrowIcon/stories.tsx
@@ -1,9 +1,10 @@
 import { Story, Meta } from '@storybook/react'
-import ArrowIcon, { ArrowIconProps } from '.'
+
+import { ArrowIcon, ArrowIconProps } from '.'
 
 export default {
   title: 'ArrowIcon',
   component: ArrowIcon,
-} as Meta
+} as Meta<ArrowIconProps>
 
 export const Default: Story<ArrowIconProps> = (args) => <ArrowIcon {...args} />

--- a/app/components/ArrowIcon/test.tsx
+++ b/app/components/ArrowIcon/test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import ArrowIcon from '.'
+import { ArrowIcon } from '.'
 
 describe('<ArrowIcon />', () => {
   it('should render correctly', () => {

--- a/app/components/DateSelector/index.tsx
+++ b/app/components/DateSelector/index.tsx
@@ -1,8 +1,11 @@
 import { format } from 'date-fns'
 import { Link, useNavigate } from 'remix'
-import ArrowIcon from '../ArrowIcon'
-import DayPickerInput from '../DayPickerInput'
+
 import { DATE_LINK_FORMAT, DATE_DISPLAY_FORMAT } from '~/constants'
+
+import { ArrowIcon } from '~/components/ArrowIcon'
+import { DayPickerInput } from '~/components/DayPickerInput'
+
 import { formatDate, parseDate } from '~/utils/handleDates'
 
 export type DateSelectorProps = {
@@ -11,13 +14,13 @@ export type DateSelectorProps = {
   prevDay: Date
 }
 
-function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
+export function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
   const navigate = useNavigate()
 
   return (
     <div className="flex flex-col py-12">
       <h1 className="mb-3 text-4xl font-bold">Games</h1>
-      <div className="justify-between pt-4 flex items-center gap-5 sm:justify-start">
+      <div className="flex items-center justify-between gap-5 pt-4 sm:justify-start">
         <Link
           prefetch="intent"
           className="p-2"
@@ -36,7 +39,7 @@ function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
             navigate(`/${format(selectedDay, DATE_LINK_FORMAT)}`)
           }
           dayPickerProps={{
-            todayButton: 'Go to today'
+            todayButton: 'Go to today',
           }}
         />
 
@@ -51,5 +54,3 @@ function DateSelector({ day, nextDay, prevDay }: DateSelectorProps) {
     </div>
   )
 }
-
-export default DateSelector

--- a/app/components/DayPickerInput/index.tsx
+++ b/app/components/DayPickerInput/index.tsx
@@ -1,6 +1,7 @@
 import type { DayPickerInputProps } from 'react-day-picker'
 import BaseDayPickerInput from 'react-day-picker/DayPickerInput'
 import styles from 'react-day-picker/lib/style.css'
+
 import customStyles from './styles.css'
 
 export const links = () => [
@@ -11,23 +12,23 @@ export const links = () => [
   },
 ]
 
-const DayPickerInput = (props: DayPickerInputProps) => (
-  <BaseDayPickerInput
-    component={(componentProps: unknown) => (
-      <input
-        className="cursor-pointer bg-inherit text-center text-lg font-semibold outline-none"
-        readOnly
-        {...componentProps}
-      />
-    )}
-    overlayComponent={(overlayProps: unknown) => (
-      <div
-        className="absolute z-10 flex rounded-lg border border-main bg-glass text-white backdrop-blur-lg duration-300 hover:cursor-pointer hover:bg-slate-700 firefox:bg-slate-750"
-        {...overlayProps}
-      />
-    )}
-    {...props}
-  />
-)
-
-export default DayPickerInput
+export function DayPickerInput(props: DayPickerInputProps) {
+  return (
+    <BaseDayPickerInput
+      component={(componentProps: unknown) => (
+        <input
+          className="cursor-pointer bg-inherit text-center text-lg font-semibold outline-none"
+          readOnly
+          {...componentProps}
+        />
+      )}
+      overlayComponent={(overlayProps: unknown) => (
+        <div
+          className="absolute z-10 flex rounded-lg border border-main bg-glass text-white backdrop-blur-lg duration-300 hover:cursor-pointer hover:bg-slate-700 firefox:bg-slate-750"
+          {...overlayProps}
+        />
+      )}
+      {...props}
+    />
+  )
+}

--- a/app/components/Footer/index.tsx
+++ b/app/components/Footer/index.tsx
@@ -1,4 +1,4 @@
-function Footer() {
+export function Footer() {
   const linkStyle = 'border-b-blue-500 text-blue-500 hover:border-b-[1px]'
 
   return (
@@ -37,5 +37,3 @@ function Footer() {
     </footer>
   )
 }
-
-export default Footer

--- a/app/components/Footer/stories.tsx
+++ b/app/components/Footer/stories.tsx
@@ -1,9 +1,10 @@
 import { Story, Meta } from '@storybook/react'
-import Footer from '.'
+
+import { Footer } from '.'
 
 export default {
   title: 'Footer',
-  component: Footer
+  component: Footer,
 } as Meta
 
 export const Default: Story = () => <Footer />

--- a/app/components/Footer/test.tsx
+++ b/app/components/Footer/test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import Footer from '.'
+import { Footer } from '.'
 
 describe('<Footer />', () => {
   it('should render correctly', () => {

--- a/app/components/GameCard/index.tsx
+++ b/app/components/GameCard/index.tsx
@@ -1,18 +1,22 @@
-import cn from 'classnames'
 import { useMemo } from 'react'
 
-import TeamInfo from '../TeamInfo'
+import cn from 'classnames'
+
 import { GAME_STATUS } from '~/constants'
-import type { Game } from '~/types'
+
+import { TeamInfo } from '~/components/TeamInfo'
+
 import { getWinner } from '~/utils/getWinner'
 import { getTimePeriod } from '~/utils/handleDates'
+
+import type { Game } from '~/types'
 
 export type GameCardProps = Game & {
   details?: boolean
   interactive?: boolean
 }
 
-const GameCard = ({
+export function GameCard({
   vTeam,
   hTeam,
   startTime,
@@ -23,7 +27,7 @@ const GameCard = ({
   clock,
   details = true,
   interactive = true,
-}: GameCardProps) => {
+}: GameCardProps) {
   const winner = useMemo(() => getWinner(vTeam, hTeam), [vTeam, hTeam])
 
   return (
@@ -90,5 +94,3 @@ const GameCard = ({
     </article>
   )
 }
-
-export default GameCard

--- a/app/components/GameCard/stories.tsx
+++ b/app/components/GameCard/stories.tsx
@@ -1,5 +1,6 @@
 import { Story, Meta } from '@storybook/react'
-import GameCard, { GameCardProps } from '.'
+
+import { GameCard, GameCardProps } from '.'
 
 export default {
   title: 'GameCard',
@@ -9,7 +10,7 @@ export default {
       default: 'dark',
     },
   },
-} as Meta
+} as Meta<GameCardProps>
 
 const teams = {
   vTeam: {

--- a/app/components/GameCard/test.tsx
+++ b/app/components/GameCard/test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import GameCard from '.'
+
+import { GameCard } from '.'
 
 const game = {
   startTime: '2022-02-12T22:00:00.000Z',

--- a/app/components/GameSummary/index.tsx
+++ b/app/components/GameSummary/index.tsx
@@ -1,5 +1,6 @@
 import { OvertimeHead, OvertimeScore } from '~/components/Overtime'
 import { Table, TableCell, TableHead } from '~/components/Table'
+
 import type { TeamScore } from '~/types'
 
 export type GameSummaryProps = {
@@ -10,7 +11,7 @@ export type GameSummaryProps = {
   }
 }
 
-function GameSummary({ game }: GameSummaryProps) {
+export function GameSummary({ game }: GameSummaryProps) {
   return (
     <div className="py-5">
       <h1 className="text-2xl font-semibold">Game Summary</h1>
@@ -49,5 +50,3 @@ function GameSummary({ game }: GameSummaryProps) {
     </div>
   )
 }
-
-export default GameSummary

--- a/app/components/GameSummary/stories.tsx
+++ b/app/components/GameSummary/stories.tsx
@@ -1,5 +1,6 @@
 import { Story, Meta } from '@storybook/react'
-import GameSummary, { GameSummaryProps } from '.'
+
+import { GameSummary, GameSummaryProps } from '.'
 
 export default {
   title: 'GameSummary',
@@ -9,7 +10,7 @@ export default {
       default: 'dark',
     },
   },
-} as Meta
+} as Meta<GameSummaryProps>
 
 export const Default: Story<GameSummaryProps> = (args) => (
   <GameSummary {...args} />

--- a/app/components/GameSummary/test.tsx
+++ b/app/components/GameSummary/test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
-import GameSummary from '.'
+
+import { GameSummary } from '.'
 
 describe('<GameSummary>', () => {
   it('should render correctly', () => {

--- a/app/components/GamesList/index.tsx
+++ b/app/components/GamesList/index.tsx
@@ -1,12 +1,14 @@
 import { Link } from 'remix'
-import GameCard from '../GameCard'
+
+import { GameCard } from '~/components/GameCard'
+
 import type { GameList } from '~/types'
 
 export type GamesListProps = {
   games: GameList[]
 }
 
-function GamesList({ games }: GamesListProps) {
+export function GamesList({ games }: GamesListProps) {
   return (
     <div className="grid grid-cols-auto-fill gap-5">
       {games.length === 0 ? (
@@ -47,5 +49,3 @@ function GamesList({ games }: GamesListProps) {
     </div>
   )
 }
-
-export default GamesList

--- a/app/components/Header/index.tsx
+++ b/app/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import { Link, NavLink } from 'remix'
 
-function Header() {
+export function Header() {
   const linkClass =
     'text-lg transition-opacity hover:opacity-70 border-b-2 border-transparent hover:border-blue-300'
   const activeLinkClass =
@@ -29,5 +29,3 @@ function Header() {
     </header>
   )
 }
-
-export default Header

--- a/app/components/Header/test.tsx
+++ b/app/components/Header/test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { LinkProps } from 'remix'
 
-import Header from '.'
+import { Header } from '.'
 
 jest.mock('remix', () => ({
   Link: ({ children }: LinkProps) => <a href="/">{children}</a>,

--- a/app/components/Layout/index.tsx
+++ b/app/components/Layout/index.tsx
@@ -1,11 +1,11 @@
-import Footer from '~/components/Footer'
-import Header from '~/components/Header'
+import { Footer } from '~/components/Footer'
+import { Header } from '~/components/Header'
 
 export type LayoutProps = {
   children: React.ReactNode
 }
 
-function Layout({ children }: LayoutProps) {
+export function Layout({ children }: LayoutProps) {
   return (
     <div className="flex min-h-screen flex-col bg-slate-900 bg-main bg-cover bg-center pb-24 text-white">
       <Header />
@@ -14,5 +14,3 @@ function Layout({ children }: LayoutProps) {
     </div>
   )
 }
-
-export default Layout

--- a/app/components/Layout/test.tsx
+++ b/app/components/Layout/test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { LinkProps } from 'remix'
 
-import Layout from '.'
+import { Layout } from '.'
 
 jest.mock('remix', () => ({
   Link: ({ children }: LinkProps) => <a href="/">{children}</a>,

--- a/app/components/Overtime/index.tsx
+++ b/app/components/Overtime/index.tsx
@@ -1,4 +1,5 @@
 import { TableCell } from '~/components/Table'
+
 import type { TeamScore } from '~/types'
 
 export type OvertimeHeadProps = {

--- a/app/components/Overtime/test.tsx
+++ b/app/components/Overtime/test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+
 import { OvertimeHead, OvertimeScore } from '.'
 
 describe('OvertimeHead', () => {

--- a/app/components/PlayersStats/index.tsx
+++ b/app/components/PlayersStats/index.tsx
@@ -1,7 +1,8 @@
 import { Table, TableCell, TableHead } from '~/components/Table'
+
 import type { PlayerStats, TeamPlayerStats } from '~/types'
 
-function PlayersStats({ team }: TeamPlayerStats) {
+export function PlayersStats({ team }: TeamPlayerStats) {
   return (
     <div>
       <h1 className="text-2xl font-bold">
@@ -36,5 +37,3 @@ function PlayersStats({ team }: TeamPlayerStats) {
     </div>
   )
 }
-
-export default PlayersStats

--- a/app/components/PlayersStats/stories.tsx
+++ b/app/components/PlayersStats/stories.tsx
@@ -1,6 +1,8 @@
 import { Story, Meta } from '@storybook/react'
-import PlayersStats from '.'
+
 import type { TeamPlayerStats } from '~/types'
+
+import { PlayersStats } from '.'
 
 export default {
   title: 'PlayersStats',
@@ -10,7 +12,7 @@ export default {
       default: 'dark',
     },
   },
-} as Meta
+} as Meta<TeamPlayerStats>
 
 export const Default: Story<TeamPlayerStats> = (args) => (
   <PlayersStats {...args} />

--- a/app/components/PlayersStats/test.tsx
+++ b/app/components/PlayersStats/test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
-import PlayersStats from '.'
+
+import { PlayersStats } from '.'
 
 describe('<PlayersStats>', () => {
   it('should render correctly', () => {

--- a/app/components/StandingTable/index.tsx
+++ b/app/components/StandingTable/index.tsx
@@ -1,26 +1,14 @@
 import { Table, TableCell, TableHead } from '~/components/Table'
-import TeamLogo from '~/components/TeamLogo'
+import { TeamLogo } from '~/components/TeamLogo'
 
-export type TeamConference = {
-  rank: string
-  name: string
-  code: string
-  win: string
-  loss: string
-  percentage: string
-  gamesBehind: string
-  homeRecord: string
-  awayRecord: string
-  lastTenRecord: string
-  streak: string
-}
+import { TeamConference } from '~/types'
 
 export type StandingTableProps = {
   label: string
   conference: TeamConference[]
 }
 
-function StandingTable({ label, conference }: StandingTableProps) {
+export function StandingTable({ label, conference }: StandingTableProps) {
   return (
     <div className="overflow-x-auto py-5">
       <h1 className="text-3xl font-bold text-white">{label}</h1>
@@ -64,5 +52,3 @@ function StandingTable({ label, conference }: StandingTableProps) {
     </div>
   )
 }
-
-export default StandingTable

--- a/app/components/StandingTable/stories.tsx
+++ b/app/components/StandingTable/stories.tsx
@@ -1,14 +1,15 @@
 import { Story, Meta } from '@storybook/react'
-import StandingTable, { StandingTableProps } from '.'
 
-export const Default: Story<StandingTableProps> = (args) => (
-  <StandingTable {...args} />
-)
+import { StandingTable, StandingTableProps } from '.'
 
 export default {
   title: 'StandingTable',
   component: StandingTable,
-} as Meta
+} as Meta<StandingTableProps>
+
+export const Default: Story<StandingTableProps> = (args) => (
+  <StandingTable {...args} />
+)
 
 Default.args = {
   label: 'Eastern Conference',

--- a/app/components/StandingTable/test.tsx
+++ b/app/components/StandingTable/test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import StandingTable from '.'
+
+import { StandingTable } from '.'
 
 describe('<StandingTable>', () => {
   it('should render correctly', () => {

--- a/app/components/Table/stories.tsx
+++ b/app/components/Table/stories.tsx
@@ -1,4 +1,5 @@
 import { Story, Meta } from '@storybook/react'
+
 import { Table, TableCell, TableHead } from '.'
 
 export default {

--- a/app/components/Table/test.tsx
+++ b/app/components/Table/test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+
 import { Table, TableCell, TableHead } from '.'
 
 describe('<Table>', () => {

--- a/app/components/TeamInfo/index.tsx
+++ b/app/components/TeamInfo/index.tsx
@@ -1,13 +1,14 @@
-import TeamLogo from '../TeamLogo'
-
 import { TEAM_NAME } from '~/constants'
+
+import { TeamLogo } from '~/components/TeamLogo'
+
 import type { Team } from '~/types'
 
 export type TeamInfoProps = {
   team: Team
 }
 
-function TeamInfo({ team }: TeamInfoProps) {
+export function TeamInfo({ team }: TeamInfoProps) {
   return (
     <div className="flex w-1/4 flex-col items-center text-center">
       <TeamLogo team={team.triCode} size={48} />
@@ -20,5 +21,3 @@ function TeamInfo({ team }: TeamInfoProps) {
     </div>
   )
 }
-
-export default TeamInfo

--- a/app/components/TeamInfo/stories.tsx
+++ b/app/components/TeamInfo/stories.tsx
@@ -1,7 +1,6 @@
 import { Story, Meta } from '@storybook/react'
-import TeamInfo, { TeamInfoProps } from '.'
 
-export const Default: Story<TeamInfoProps> = (args) => <TeamInfo {...args} />
+import { TeamInfo, TeamInfoProps } from '.'
 
 export default {
   title: 'TeamInfo',
@@ -9,7 +8,9 @@ export default {
   parameters: {
     layout: 'fullscreen',
   },
-} as Meta
+} as Meta<TeamInfoProps>
+
+export const Default: Story<TeamInfoProps> = (args) => <TeamInfo {...args} />
 
 Default.args = {
   team: {

--- a/app/components/TeamInfo/test.tsx
+++ b/app/components/TeamInfo/test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import TeamInfo from '.'
+
+import { TeamInfo } from '.'
 
 const team = {
   score: '',

--- a/app/components/TeamLogo/index.tsx
+++ b/app/components/TeamLogo/index.tsx
@@ -5,7 +5,7 @@ export type TeamLogoProps = {
   size?: number
 }
 
-function TeamLogo({ team, size }: TeamLogoProps) {
+export function TeamLogo({ team, size }: TeamLogoProps) {
   const Icon = NBAIcons[team as keyof typeof NBAIcons]
 
   return Icon ? (
@@ -16,5 +16,3 @@ function TeamLogo({ team, size }: TeamLogoProps) {
     </div>
   )
 }
-
-export default TeamLogo

--- a/app/components/TeamLogo/stories.tsx
+++ b/app/components/TeamLogo/stories.tsx
@@ -1,6 +1,8 @@
 import { Story, Meta } from '@storybook/react'
-import TeamLogo, { TeamLogoProps } from '.'
+
 import { TEAM_NAME } from '~/constants'
+
+import { TeamLogo, TeamLogoProps } from '.'
 
 export default {
   title: 'TeamLogo',
@@ -11,7 +13,7 @@ export default {
       control: { type: 'select' },
     },
   },
-} as Meta
+} as Meta<TeamLogoProps>
 
 export const Default: Story<TeamLogoProps> = (args) => <TeamLogo {...args} />
 

--- a/app/components/TeamLogo/test.tsx
+++ b/app/components/TeamLogo/test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import TeamLogo from '.'
+import { TeamLogo } from '.'
 
 describe('<TeamLogo />', () => {
   it('should render the team TeamLogo', () => {

--- a/app/components/TeamStats/index.tsx
+++ b/app/components/TeamStats/index.tsx
@@ -1,4 +1,5 @@
 import { Table, TableCell } from '~/components/Table'
+
 import type { TeamGroupStatistics } from '~/types'
 
 export type StatisticProps = {
@@ -21,7 +22,7 @@ export function Statistic({
   )
 }
 
-function TeamStats({ game }: TeamGroupStatistics) {
+export function TeamStats({ game }: TeamGroupStatistics) {
   return (
     <div>
       <h1 className="text-2xl font-bold">Team Stats</h1>
@@ -109,5 +110,3 @@ function TeamStats({ game }: TeamGroupStatistics) {
     </div>
   )
 }
-
-export default TeamStats

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,3 +1,8 @@
+export const API_URL = {
+  base: 'http://data.nba.net/prod/',
+  details: 'https://data.nba.com/',
+}
+
 export const TEAM_NAME = {
   ATL: 'Hawks',
   BKN: 'Nets',

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -1,4 +1,4 @@
-import { hydrate } from "react-dom";
-import { RemixBrowser } from "remix";
+import { hydrate } from 'react-dom'
+import { RemixBrowser } from 'remix'
 
-hydrate(<RemixBrowser />, document);
+hydrate(<RemixBrowser />, document)

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,21 +1,21 @@
-import { renderToString } from "react-dom/server";
-import { RemixServer } from "remix";
-import type { EntryContext } from "remix";
+import { renderToString } from 'react-dom/server'
+import { RemixServer } from 'remix'
+import type { EntryContext } from 'remix'
 
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
   responseHeaders: Headers,
-  remixContext: EntryContext
+  remixContext: EntryContext,
 ) {
   const markup = renderToString(
-    <RemixServer context={remixContext} url={request.url} />
-  );
+    <RemixServer context={remixContext} url={request.url} />,
+  )
 
-  responseHeaders.set("Content-Type", "text/html");
+  responseHeaders.set('Content-Type', 'text/html')
 
-  return new Response("<!DOCTYPE html>" + markup, {
+  return new Response('<!DOCTYPE html>' + markup, {
     status: responseStatusCode,
-    headers: responseHeaders
-  });
+    headers: responseHeaders,
+  })
 }

--- a/app/hooks/use-revalidate-on-interval.ts
+++ b/app/hooks/use-revalidate-on-interval.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react'
+
 import { useRevalidate } from 'remix-utils'
 
 interface Options {
   interval?: number
 }
 
-export default function useRevalidateOnInterval({ interval = 1000 }: Options) {
+export function useRevalidateOnInterval({ interval = 1000 }: Options) {
   let revalidate = useRevalidate()
 
   useEffect(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,7 +1,7 @@
-import NProgress from 'nprogress'
-import nProgressStyles from 'nprogress/nprogress.css'
 import { useEffect } from 'react'
 
+import NProgress from 'nprogress'
+import nProgressStyles from 'nprogress/nprogress.css'
 import {
   Links,
   LiveReload,
@@ -13,7 +13,7 @@ import {
 } from 'remix'
 import type { LinksFunction, MetaFunction } from 'remix'
 
-import Layout from './components/Layout'
+import { Layout } from './components/Layout'
 import styles from './tailwind.css'
 
 export const meta: MetaFunction = () => {
@@ -29,9 +29,9 @@ export const links: LinksFunction = () => {
 
 export type ErrorBoundaryProps = {
   error: {
-    message: String,
-    stack: String,
-  },
+    message: String
+    stack: String
+  }
 }
 
 export default function App() {
@@ -81,11 +81,11 @@ export default function App() {
   )
 }
 
-export function ErrorBoundary({ error } : ErrorBoundaryProps) {
-  console.error(error);
+export function ErrorBoundary({ error }: ErrorBoundaryProps) {
+  console.error(error)
 
   return (
-    <html lang='en'>
+    <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -95,11 +95,11 @@ export function ErrorBoundary({ error } : ErrorBoundaryProps) {
       </head>
       <body>
         <Layout>
-          <h1 className="text-4xl font-bold mb-2">Oh no!</h1>
+          <h1 className="mb-2 text-4xl font-bold">Oh no!</h1>
           <h2 className="text-2xl font-semibold">Something went wrong.</h2>
         </Layout>
         <Scripts />
       </body>
     </html>
-  );
+  )
 }

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -3,18 +3,19 @@ import { LinksFunction, useLoaderData, useParams } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
-import DateSelector from '~/components/DateSelector'
-import { links as dayPickerInputStyles } from '~/components/DayPickerInput'
-import GamesList from '~/components/GamesList'
-import Layout from '~/components/Layout'
 
 import { DATE_DISPLAY_FORMAT, TIME_TO_REFETCH } from '~/constants'
 
-import useRevalidateOnInterval from '~/hooks/use-revalidate-on-interval'
+import { DateSelector } from '~/components/DateSelector'
+import { links as dayPickerInputStyles } from '~/components/DayPickerInput'
+import { GamesList } from '~/components/GamesList'
+import { Layout } from '~/components/Layout'
 
 import { cachedJson } from '~/utils/cachedJson'
 import { getDays } from '~/utils/handleDates'
 import { getSocialMetas, getUrl } from '~/utils/seo'
+
+import { useRevalidateOnInterval } from '~/hooks/use-revalidate-on-interval'
 
 export const links: LinksFunction = () => [...dayPickerInputStyles()]
 

--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -3,18 +3,19 @@ import { useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
-import ArrowIcon from '~/components/ArrowIcon'
-import GameCard from '~/components/GameCard'
-import GameSummary from '~/components/GameSummary'
-import Layout from '~/components/Layout'
-import PlayerStats from '~/components/PlayersStats'
-import TeamStats from '~/components/TeamStats'
 
 import { DATE_DISPLAY_FORMAT, GAME_STATUS, TIME_TO_REFETCH } from '~/constants'
 
-import useRevalidateOnInterval from '~/hooks/use-revalidate-on-interval'
+import { ArrowIcon } from '~/components/ArrowIcon'
+import { GameCard } from '~/components/GameCard'
+import { GameSummary } from '~/components/GameSummary'
+import { Layout } from '~/components/Layout'
+import { PlayersStats } from '~/components/PlayersStats'
+import { TeamStats } from '~/components/TeamStats'
 
 import { getSocialMetas, getUrl } from '~/utils/seo'
+
+import { useRevalidateOnInterval } from '~/hooks/use-revalidate-on-interval'
 
 export const meta: MetaFunction = ({ data }) => {
   const date = new Date(data.game.startTimeUTC)
@@ -103,8 +104,8 @@ export default function Game() {
           <GameSummary game={game} />
 
           <div className="flex gap-4 overflow-x-auto md:gap-12 ">
-            <PlayerStats team={game.hTeam} />
-            <PlayerStats team={game.vTeam} />
+            <PlayersStats team={game.hTeam} />
+            <PlayersStats team={game.vTeam} />
 
             <TeamStats game={game} />
           </div>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -3,17 +3,18 @@ import { LinksFunction, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
-import DateSelector from '~/components/DateSelector'
-import { links as dayPickerInputStyles } from '~/components/DayPickerInput'
-import GamesList from '~/components/GamesList'
-import Layout from '~/components/Layout'
 
 import { DATE_LINK_FORMAT, TIME_TO_REFETCH } from '~/constants'
 
-import useRevalidateOnInterval from '~/hooks/use-revalidate-on-interval'
+import { DateSelector } from '~/components/DateSelector'
+import { links as dayPickerInputStyles } from '~/components/DayPickerInput'
+import { GamesList } from '~/components/GamesList'
+import { Layout } from '~/components/Layout'
 
 import { getDays } from '~/utils/handleDates'
 import { getSocialMetas, getUrl } from '~/utils/seo'
+
+import { useRevalidateOnInterval } from '~/hooks/use-revalidate-on-interval'
 
 export const links: LinksFunction = () => [...dayPickerInputStyles()]
 

--- a/app/routes/standings.tsx
+++ b/app/routes/standings.tsx
@@ -2,8 +2,9 @@ import { useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
-import Layout from '~/components/Layout'
-import StandingTable from '~/components/StandingTable'
+
+import { Layout } from '~/components/Layout'
+import { StandingTable } from '~/components/StandingTable'
 
 import { cachedJson } from '~/utils/cachedJson'
 import { conferenceMapper } from '~/utils/mappers'

--- a/app/types.ts
+++ b/app/types.ts
@@ -56,6 +56,40 @@ export type TeamPlayerStats = {
   }
 }
 
+export type TeamStanding = {
+  teamSitesOnly: {
+    teamNickname: string
+    teamTricode: string
+  }
+  teamId: string
+  confRank: string
+  win: string
+  loss: string
+  winPctV2: string
+  gamesBehind: string
+  homeWin: string
+  homeLoss: string
+  awayWin: string
+  awayLoss: string
+  lastTenWin: string
+  lastTenLoss: string
+  isWinStreak: boolean
+  streak: string
+}
+
+export type TeamConference = {
+  rank: string
+  name: string
+  code: string
+  win: string
+  loss: string
+  percentage: string
+  gamesBehind: string
+  homeRecord: string
+  awayRecord: string
+  lastTenRecord: string
+  streak: string
+}
 export type PlayerStats = {
   num: string
   fn: string
@@ -90,27 +124,6 @@ export type GameList = {
   clock?: string
   vTeam: Team
   hTeam: Team
-}
-
-export type TeamStanding = {
-  teamSitesOnly: {
-    teamNickname: string
-    teamTricode: string
-  }
-  teamId: string
-  confRank: string
-  win: string
-  loss: string
-  winPctV2: string
-  gamesBehind: string
-  homeWin: string
-  homeLoss: string
-  awayWin: string
-  awayLoss: string
-  lastTenWin: string
-  lastTenLoss: string
-  isWinStreak: boolean
-  streak: string
 }
 
 export type SocialMetas = {

--- a/app/utils/handleDates/index.ts
+++ b/app/utils/handleDates/index.ts
@@ -12,6 +12,7 @@ import {
 } from 'date-fns'
 import { utcToZonedTime } from 'date-fns-tz'
 import { DateUtils } from 'react-day-picker'
+
 import { EST_IANA_ZONE_ID, GAME_STATUS } from '~/constants'
 
 const COVID_YEAR = 2020

--- a/app/utils/mappers/index.ts
+++ b/app/utils/mappers/index.ts
@@ -1,4 +1,5 @@
 import { EAST_TEAMS, WEST_TEAMS } from '~/constants'
+
 import type { TeamStanding } from '~/types'
 
 export const conferenceMapper = (teams: TeamStanding[], isEast: boolean) =>

--- a/app/utils/seo/index.ts
+++ b/app/utils/seo/index.ts
@@ -1,4 +1,5 @@
 import urljoin from 'url-join'
+
 import { DEFAULT_DOMAIN } from '~/constants'
 
 import type { SocialMetas } from '~/types'

--- a/generators/templates/Component.tsx.hbs
+++ b/generators/templates/Component.tsx.hbs
@@ -1,5 +1,3 @@
-function {{pascalCase name}}() {
+export function {{pascalCase name}}() {
   return <h1>{{pascalCase name}}</h1>
 }
-
-export default {{pascalCase name}}

--- a/generators/templates/stories.tsx.hbs
+++ b/generators/templates/stories.tsx.hbs
@@ -1,5 +1,6 @@
 import { Story, Meta } from '@storybook/react'
-import {{pascalCase name}} from '.'
+
+import { {{pascalCase name}} } from '.'
 
 export default {
   title: '{{pascalCase name}}',

--- a/generators/templates/test.tsx.hbs
+++ b/generators/templates/test.tsx.hbs
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 
-import {{pascalCase name}} from '.'
+import { {{pascalCase name}} } from '.'
 
 describe('<{{pascalCase name}} />', () => {
   it('should render the heading', () => {

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw'
-import { API_URL } from '~/api'
+
+import { API_URL } from '~/constants'
 
 export const handlers = [
   // [GET] API.getStandings()

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,9 @@
         "eslint": "^8.10.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "husky": "^7.0.4",
         "jest": "^27.5.1",
+        "lint-staged": "^12.3.5",
         "msw": "^0.39.1",
         "plop": "^3.0.5",
         "postcss": "^8.4.8",
@@ -9018,6 +9020,15 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/astring": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.1.tgz",
@@ -10770,6 +10781,72 @@
         "colors": "1.4.0"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -10893,6 +10970,12 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -12681,6 +12764,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -16924,6 +17013,21 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -20255,6 +20359,185 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lint-staged": {
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
+      "integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.16",
+        "commander": "^8.3.0",
+        "debug": "^4.3.3",
+        "execa": "^5.1.1",
+        "lilconfig": "2.0.4",
+        "listr2": "^4.0.1",
+        "micromatch": "^4.0.4",
+        "normalize-path": "^3.0.0",
+        "object-inspect": "^1.12.0",
+        "string-argv": "^0.3.1",
+        "supports-color": "^9.2.1",
+        "yaml": "^1.10.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/lint-staged/node_modules/debug": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lint-staged/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/lint-staged/node_modules/supports-color": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.1.tgz",
+      "integrity": "sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/rxjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/listr2/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -20346,6 +20629,88 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/longest-streak": {
@@ -25819,6 +26184,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -26579,6 +26950,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+      "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -27248,6 +27659,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -37128,6 +37548,12 @@
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
+    },
     "astring": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.1.tgz",
@@ -38483,6 +38909,50 @@
         "string-width": "^4.2.0"
       }
     },
+    "cli-truncate": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -38579,6 +39049,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
     "colors": {
@@ -40024,6 +40500,12 @@
           }
         }
       }
+    },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -43177,6 +43659,12 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "husky": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -45619,6 +46107,134 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "lint-staged": {
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.5.tgz",
+      "integrity": "sha512-oOH36RUs1It7b9U/C7Nl/a0sLfoIBcMB8ramiB3nuJ6brBqzsWiUAFSR5DQ3yyP/OR7XKMpijtgKl2DV1lQ3lA==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.16",
+        "commander": "^8.3.0",
+        "debug": "^4.3.3",
+        "execa": "^5.1.1",
+        "lilconfig": "2.0.4",
+        "listr2": "^4.0.1",
+        "micromatch": "^4.0.4",
+        "normalize-path": "^3.0.0",
+        "object-inspect": "^1.12.0",
+        "string-argv": "^0.3.1",
+        "supports-color": "^9.2.1",
+        "yaml": "^1.10.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.2.1.tgz",
+          "integrity": "sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==",
+          "dev": true
+        }
+      }
+    },
+    "listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cli-truncate": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+          "dev": true,
+          "requires": {
+            "slice-ansi": "^3.0.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -45690,6 +46306,66 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
           "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
           "dev": true
+        }
+      }
+    },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },
@@ -49760,6 +50436,12 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -50390,6 +51072,30 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.1.0.tgz",
+          "integrity": "sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+          "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+          "dev": true
+        }
+      }
+    },
     "snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -50966,6 +51672,12 @@
           "dev": true
         }
       }
+    },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,19 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "generate": "plop --plopfile generators/plopfile.js",
-    "lint": "eslint app --max-warnings=0"
+    "lint": "eslint app --max-warnings=0",
+    "prepare": "husky install"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.{ts,tsx}": [
+      "yarn eslint --fix",
+      "yarn prettier --write"
+    ]
   },
   "dependencies": {
     "@remix-run/react": "^1.2.3",
@@ -62,7 +74,9 @@
     "eslint": "^8.10.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "husky": "^7.0.4",
     "jest": "^27.5.1",
+    "lint-staged": "^12.3.5",
     "msw": "^0.39.1",
     "plop": "^3.0.5",
     "postcss": "^8.4.8",


### PR DESCRIPTION
- Based on [this doc](https://basarat.gitbook.io/typescript/main-1/defaultisbad), I updated components removing `default export`.
- Added `husky` to run `eslint` and `prettier` on pre-commig.