### PR TITLE
Add cookie utils to set and get the favoriteTeam - closes #103

### DIFF
--- a/app/cookies.ts
+++ b/app/cookies.ts
@@ -1,0 +1,21 @@
+import { createCookie } from 'remix'
+
+import { Team, UserPreferences } from '~/types'
+
+const ONE_MONTH_IN_SECONDS = 30 * 24 * 60 * 60
+
+const userPrefsCookie = createCookie('user-prefs', {
+  maxAge: ONE_MONTH_IN_SECONDS,
+})
+
+export async function getUserPrefsCookie(request: Request) {
+  const cookie: UserPreferences =
+    (await userPrefsCookie.parse(request.headers.get('Cookie'))) || {}
+  return {
+    getFavoriteTeam: (): Team | undefined => cookie.favoriteTeam,
+    setFavoriteTeam: (team: Team) => {
+      cookie.favoriteTeam = team
+    },
+    commitUserPrefs: () => userPrefsCookie.serialize(cookie),
+  }
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -133,3 +133,7 @@ export type SocialMetas = {
   origin?: string
   image?: string
 }
+
+export type UserPreferences = {
+  favoriteTeam: Team | undefined
+}


### PR DESCRIPTION
Proposal to #103

As recommended in [Remix Docs Cookies Section](https://remix.run/docs/en/v1/api/remix#cookies), I created the cookie utils inside `app/cookies.ts`. 

## Some questions
- Should we use a general solution like userPrefs or go for favoriteTeam only?
- Should this cookie expires? If so, how long is suitable?