### PR TITLE
Update revalidation with useFetcher

### DIFF
--- a/app/hooks/use-revalidate-on-interval.ts
+++ b/app/hooks/use-revalidate-on-interval.ts
@@ -11,8 +11,8 @@ export function useRevalidateOnInterval({
   interval = 1000,
   revalidateFn,
 }: Options) {
-  let defaultRevalidate = useRevalidate()
-  let revalidate = revalidateFn ?? defaultRevalidate
+  const defaultRevalidate = useRevalidate()
+  const revalidate = revalidateFn ?? defaultRevalidate
 
   useEffect(
     function revalidateOnInterval() {

--- a/app/hooks/use-revalidate-on-interval.ts
+++ b/app/hooks/use-revalidate-on-interval.ts
@@ -4,10 +4,15 @@ import { useRevalidate } from 'remix-utils'
 
 interface Options {
   interval?: number
+  revalidateFn?: () => void
 }
 
-export function useRevalidateOnInterval({ interval = 1000 }: Options) {
-  let revalidate = useRevalidate()
+export function useRevalidateOnInterval({
+  interval = 1000,
+  revalidateFn,
+}: Options) {
+  let defaultRevalidate = useRevalidate()
+  let revalidate = revalidateFn ?? defaultRevalidate
 
   useEffect(
     function revalidateOnInterval() {

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -58,14 +58,16 @@ export default function Index() {
 
   const [games, setGames] = useState(loaderGames)
 
-  const revalidateFn = () => {
-    //Revalidate only when browser tab is active
+  const revalidateOnActiveTab = () => {
     if (document.visibilityState === 'visible') {
       fetcher.load(`/${date}`)
     }
   }
 
-  useRevalidateOnInterval({ interval: TIME_TO_REFETCH, revalidateFn })
+  useRevalidateOnInterval({
+    interval: TIME_TO_REFETCH,
+    revalidateFn: revalidateOnActiveTab,
+  })
 
   useEffect(() => {
     if (fetcher.data) {

--- a/app/routes/$date.tsx
+++ b/app/routes/$date.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
+
 import { format } from 'date-fns'
-import { LinksFunction, useLoaderData, useParams } from 'remix'
+import { LinksFunction, useFetcher, useLoaderData, useParams } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -49,11 +51,30 @@ export const loader: LoaderFunction = async ({ params, request }) => {
 }
 
 export default function Index() {
-  useRevalidateOnInterval({ interval: TIME_TO_REFETCH })
   const { date } = useParams()
   const { day, prevDay, nextDay } = getDays(date)
+  const { games: loaderGames } = useLoaderData()
+  const fetcher = useFetcher()
 
-  const { games } = useLoaderData()
+  const [games, setGames] = useState(loaderGames)
+
+  const revalidateFn = () => {
+    //Revalidate only when browser tab is active
+    if (document.visibilityState === 'visible') {
+      fetcher.load(`/${date}`)
+    }
+  }
+
+  useRevalidateOnInterval({ interval: TIME_TO_REFETCH, revalidateFn })
+
+  useEffect(() => {
+    if (fetcher.data) {
+      const { games } = fetcher.data
+      setGames(games)
+    }
+  }, [fetcher.data])
+
+  useEffect(() => setGames(loaderGames), [loaderGames, date])
 
   return (
     <Layout>

--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -77,8 +77,7 @@ export default function Game() {
 
   const [game, setGame] = useState(loaderGame)
 
-  const revalidateFn = () => {
-    //Revalidate only when browser tab is active
+  const revalidateOnActiveTab = () => {
     if (document.visibilityState === 'visible') {
       fetcher.load(`/game/${params.year}/${params.gameId}`)
     }
@@ -86,7 +85,10 @@ export default function Game() {
 
   const handleBackButton = () => window.history.back()
 
-  useRevalidateOnInterval({ interval: TIME_TO_REFETCH, revalidateFn })
+  useRevalidateOnInterval({
+    interval: TIME_TO_REFETCH,
+    revalidateFn: revalidateOnActiveTab,
+  })
 
   useEffect(() => {
     if (fetcher.data) {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -52,14 +52,16 @@ export default function Index() {
   const fetcher = useFetcher()
   const [games, setGames] = useState(loaderGames)
 
-  const revalidateFn = () => {
-    //Revalidate only when browser tab is active
+  const revalidateOnActiveTab = () => {
     if (document.visibilityState === 'visible') {
-      fetcher.load('/')
+      fetcher.load('?index')
     }
   }
 
-  useRevalidateOnInterval({ interval: TIME_TO_REFETCH, revalidateFn })
+  useRevalidateOnInterval({
+    interval: TIME_TO_REFETCH,
+    revalidateFn: revalidateOnActiveTab,
+  })
 
   useEffect(() => {
     if (fetcher.data) {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
+
 import { format } from 'date-fns'
-import { LinksFunction, useLoaderData } from 'remix'
+import { LinksFunction, useFetcher, useLoaderData } from 'remix'
 import type { LoaderFunction, MetaFunction } from 'remix'
 
 import API from '~/api'
@@ -46,8 +48,25 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 export default function Index() {
   const { day, prevDay, nextDay } = getDays()
-  const { games } = useLoaderData()
-  useRevalidateOnInterval({ interval: TIME_TO_REFETCH })
+  const { games: loaderGames } = useLoaderData()
+  const fetcher = useFetcher()
+  const [games, setGames] = useState(loaderGames)
+
+  const revalidateFn = () => {
+    //Revalidate only when browser tab is active
+    if (document.visibilityState === 'visible') {
+      fetcher.load('/')
+    }
+  }
+
+  useRevalidateOnInterval({ interval: TIME_TO_REFETCH, revalidateFn })
+
+  useEffect(() => {
+    if (fetcher.data) {
+      const { games } = fetcher.data
+      setGames(games)
+    }
+  }, [fetcher.data])
 
   return (
     <Layout>


### PR DESCRIPTION
Hey there 👋, Congrats on the amazing project!

## Context
I noticed that, specially on mobile devices, the `useRevalidateOnInterval` will cause a scroll to top behavior as it reloads the page in order to fetch latest data.

## Proposed solution
I was checking if there is an alternative way of revalidate data on the background, and found [useFetcher](https://remix.run/docs/en/v1/api/remix#usefetcher) that seems to fit! So the idea in this MR is to:
1. Store the data to be shown into an state, and initialize that data with the loader
2. Set that state with `useFetcher` data when revalidation begins

It seems to work, but not entirely sure that it would be the best way. Let me know your thoughts and feel free to ask any change you think appropriate 😃 ! I hope it can be helpful

## Before (interval time 1seg)
https://user-images.githubusercontent.com/50624358/158805380-6c3e20a2-03ca-41dc-a15e-b81ca66117ad.mov 

## After (interval time 1seg)
https://user-images.githubusercontent.com/50624358/158805463-1cf73e6e-1e57-4535-952c-4a2b80c56dd1.mov
