### PR TITLE
Update GameDetails title to show the game score - closes #111

### DIFF
--- a/app/routes/game/$year/$gameId.tsx
+++ b/app/routes/game/$year/$gameId.tsx
@@ -18,7 +18,7 @@ import { TeamStats } from '~/components/TeamStats'
 import { getSocialMetas, getUrl } from '~/utils/seo'
 
 import { useRevalidateOnInterval } from '~/hooks/use-revalidate-on-interval'
-import { Game, RequestInfo } from '~/types'
+import { GameDetailsData, RequestInfo } from '~/types'
 
 export const meta: MetaFunction = ({ data }) => {
   const date = new Date(data.game.startTimeUTC)
@@ -37,7 +37,7 @@ export const meta: MetaFunction = ({ data }) => {
 }
 
 export type LoaderData = {
-  game: Game
+  game: GameDetailsData
   requestInfo: RequestInfo
 }
 
@@ -58,7 +58,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   return json<LoaderData>({
     game: {
       // This is needed because the NBA API returns the date separated
-      startTimeUTC: new Date(`${game.gdtutc} ${game.utctm} UTC`),
+      startTimeUTC: `${new Date(`${game.gdtutc} ${game.utctm} UTC`)}`,
       period: game.p,
       clock: game.cl,
       status: Number(game.st),
@@ -78,13 +78,13 @@ export const loader: LoaderFunction = async ({ params, request }) => {
 }
 
 export default function GameDetails() {
-  const { game: loaderGame } = useLoaderData()
+  const { game: loaderGame } = useLoaderData<LoaderData>()
   const fetcher = useFetcher()
   const params = useParams()
 
   const [game, setGame] = useState(loaderGame)
 
-  const setTitle = (game: Game) => {
+  const setTitle = (game: GameDetailsData) => {
     document.title = `${game.vTeam.tn} ${game.vTeam.score} x ${game.hTeam.score} ${game.hTeam.tn} | NBA Remix`
   }
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -4,6 +4,7 @@ export type RequestInfo = {
 }
 
 export type Team = {
+  tn?: string
   score?: string
   triCode: string
   win?: string
@@ -106,7 +107,8 @@ export type PlayerStats = {
 }
 
 export type Game = {
-  startTime: string
+  startTimeUTC?: Date
+  startTime?: string
   status: number
   period: number
   isHalftime?: boolean

--- a/app/types.ts
+++ b/app/types.ts
@@ -108,7 +108,7 @@ export type PlayerStats = {
 
 export type Game = {
   startTimeUTC?: Date
-  startTime?: string
+  startTime: string
   status: number
   period: number
   isHalftime?: boolean
@@ -143,4 +143,15 @@ export type SocialMetas = {
 
 export type UserPreferences = {
   favoriteTeam: Team | undefined
+}
+
+export type GameDetailsData = {
+  startTimeUTC: string
+  status: number
+  period: number
+  isHalftime?: boolean
+  isEndOfPeriod?: boolean
+  clock?: string
+  vTeam: Team & TeamScore & TeamPlayerStats['team'] & TeamStatistic
+  hTeam: Team & TeamScore & TeamPlayerStats['team'] & TeamStatistic
 }


### PR DESCRIPTION
## Description

This PR adds the option to show the game score right into the browser tab with its title. I also added the same typing that @vedovelli did on #109 and since we need this title to be updated even without being the active tab, I removed the logic to check the tab (note: this only occurs on this page, the index page will keep the refetch only when active)

## After

![WhatsApp Image 2022-03-20 at 10 48 23 PM](https://user-images.githubusercontent.com/3991845/159196551-bb1d7b33-1c48-4ec8-805a-3f8cbe328935.jpeg)
